### PR TITLE
Initial flit support

### DIFF
--- a/jsonurl_py.py
+++ b/jsonurl_py.py
@@ -1,3 +1,11 @@
+"""
+Python implementation of jsonurl, an alternative format for JSON data model
+
+See https://jsonurl.org/ and https://github.com/jsonurl/specification/
+"""
+
+__version__ = "0.1.0"
+
 import re
 from typing import Any, Tuple, Optional
 from urllib.parse import quote_plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "jsonurl-py"
 version = "0.0.0"
 authors = [{ name = "Leonard Crestez", email = "cdleonard@gmail.com" }]
+readme = "README.rst"
 license = { file = "LICENSE" }
 classifiers = ["License :: OSI Approved :: MIT License"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = { file = "LICENSE.txt" }
 
 [project.optional-dependencies]
 test = ["pytest"]
-hack = ["tox", "black", "pre-commit"]
+hack = ["tox", "black", "pre-commit", "flit"]
 
 [build-system]
 requires = ["setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "jsonurl-py"
-version = "0.0.0"
 authors = [{ name = "Leonard Crestez", email = "cdleonard@gmail.com" }]
 readme = "README.rst"
 license = { file = "LICENSE" }
 classifiers = ["License :: OSI Approved :: MIT License"]
+dynamic = ["version", "description"]
 
 [project.urls]
 Home = "https://github.com/cdleonard/jsonurl-py"
@@ -14,8 +14,5 @@ test = ["pytest"]
 hack = ["tox", "black", "pre-commit", "flit"]
 
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-py-modules = ["jsonurl_py"]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ readme = "README.rst"
 license = { file = "LICENSE" }
 classifiers = ["License :: OSI Approved :: MIT License"]
 
+[project.urls]
+Home = "https://github.com/cdleonard/jsonurl-py"
+
 [project.optional-dependencies]
 test = ["pytest"]
 hack = ["tox", "black", "pre-commit", "flit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ hack = ["tox", "black", "pre-commit", "flit"]
 [build-system]
 requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
+
+[tool.flit.module]
+name = "jsonurl_py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "jsonurl-py"
 version = "0.0.0"
 authors = [{ name = "Leonard Crestez", email = "cdleonard@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { file = "LICENSE" }
+classifiers = ["License :: OSI Approved :: MIT License"]
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
- jsonurl-py: Initial module-level docstring and __version__
- pyproject.toml: Add flit to [hack]
- pyproject.toml: Fix license
- pyproject.toml: Add readme link
- pyproject.toml: Add project.urls.Home
- pyproject.toml: Initial switch to flit
- tool.flit.module.name = jsonurl_py
